### PR TITLE
Add average scores directly on dashboard page

### DIFF
--- a/src/features/dashboard/timeslots/starters/StarterRow.tsx
+++ b/src/features/dashboard/timeslots/starters/StarterRow.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { getStarterHighlightType, getHighlightStyle } from '../content-utils';
+import { getHighlightStyle, getStarterHighlightType } from '../content-utils';
 import PlayerModalContext from '../../player-modal/PlayerModalContext';
 import { logStarterClicked } from '../../bi';
 
@@ -15,13 +15,19 @@ interface StarterRowProps {
     isHome?: boolean;
     isUser?: boolean;
     isByGameView?: boolean;
+    scores?: { [leagueId: string]: number };
 }
 
 const StarterRow: React.FC<StarterRowProps> = (props) => {
-    const { id, position, firstName, lastName, team, multipliers, isConflicted, oppTeam, isHome, isUser: isUserTeam, isByGameView } = props;
+    const { id, position, firstName, lastName, team, multipliers, isConflicted, oppTeam, isHome, isUser: isUserTeam, isByGameView, scores } = props;
     const highlightType = getStarterHighlightType(multipliers, isConflicted, isUserTeam);
     const highlightStyle = highlightType ? getHighlightStyle(highlightType) : null;
     const { openPlayerModal } = useContext(PlayerModalContext);
+
+    // Compute average score
+    const averageScore = scores && Object.keys(scores).length > 0
+        ? Object.values(scores).reduce((sum, score) => sum + score, 0) / Object.keys(scores).length
+        : null;
 
     const onStarterClick = () => {
         logStarterClicked();
@@ -31,21 +37,33 @@ const StarterRow: React.FC<StarterRowProps> = (props) => {
     return (
         <li className='flex items-center cursor-pointer py-2' onClick={onStarterClick}>
             <div className={`text-sm pb-1 md:text-base grid grid-cols-4
-            w-full ${highlightStyle ? `font-bold ${highlightStyle.textColor}` : ''}`}>
+            w-full ${highlightStyle ? 'font-bold' : ''}`}>
                 <div className='flex w-full col-span-3'>
-                    <p className={'w-[4ch]'}>{`${position}`}</p>
-                    <p>
-                        <span className={`hidden md:inline pr-1 lg:pr-2`}>{highlightStyle?.emoji}</span>
-                        <span className="hidden sm:inline">{`${firstName}\t\t`}</span>
-                        <span>{lastName}</span>
-                        {multipliers && multipliers > 1 && <span className='hidden lg:inline'>{` (X${multipliers})`}</span>}
-                    </p>
+                    <p className='w-[4ch]'>{`${position}`}</p>
+                    <div className='flex flex-col'>
+                        <p>
+                            <span className={`hidden md:inline pr-1 lg:pr-2`}>{highlightStyle?.emoji}</span>
+                            <span className="hidden sm:inline">{`${firstName}\t\t`}</span>
+                            <span>{lastName}</span>
+                            {multipliers && multipliers > 1 && <span className='hidden lg:inline'>{` (X${multipliers})`}</span>}
+                        </p>
+                    </div>
                 </div>
                 <p className='justify-self-end md:justify-self-start'>
                     {position !== 'DEF' && <span>{`${team}`}</span>}
                     {isByGameView ? null : <span className="hidden md:inline md:pl-1 lg:pl-2">{isHome ? 'vs.' : '@'}{'\t'}{oppTeam}</span>}
                 </p>
+                <div className='col-span-4'>
+                    {averageScore !== null && averageScore > 0.0 && (
+                        <p className='text-[10px] lg:text-sm text-gray-400 mt-0.5 text-left'>
+                            <span className='hidden sm:inline'>Average score: </span>
+                            <span className='sm:hidden'>Avg. score: </span>
+                            {averageScore.toFixed(1)}
+                        </p>
+                    )}
+                </div>
             </div>
+
         </li>
     )
 };

--- a/src/features/dashboard/timeslots/starters/StarterRow.tsx
+++ b/src/features/dashboard/timeslots/starters/StarterRow.tsx
@@ -40,7 +40,7 @@ const StarterRow: React.FC<StarterRowProps> = (props) => {
     return (
         <li className='flex items-center cursor-pointer py-2' onClick={onStarterClick}>
             <div className={`text-sm pb-1 md:text-base grid grid-cols-4
-            w-full ${highlightStyle ? 'font-bold' : ''}`}>
+            w-full ${highlightStyle ? `font-bold ${highlightStyle.textColor}` : ''}`}>
                 <div className='flex w-full col-span-3'>
                     <p className='w-[4ch]'>{`${position}`}</p>
                     <div className='flex flex-col'>

--- a/src/features/dashboard/timeslots/starters/StarterRow.tsx
+++ b/src/features/dashboard/timeslots/starters/StarterRow.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import { getHighlightStyle, getStarterHighlightType } from '../content-utils';
 import PlayerModalContext from '../../player-modal/PlayerModalContext';
 import { logStarterClicked } from '../../bi';
+import { useGetLocalStorage } from '../../../local-storage/hooks';
 
 interface StarterRowProps {
     id: string;
@@ -24,7 +25,9 @@ const StarterRow: React.FC<StarterRowProps> = (props) => {
     const highlightStyle = highlightType ? getHighlightStyle(highlightType) : null;
     const { openPlayerModal } = useContext(PlayerModalContext);
 
-    // Compute average score
+    const { data: cachedSettings } = useGetLocalStorage('settings');
+    const shouldShowAverageScore = cachedSettings?.shouldShowAverageScore ?? true; // Default to true
+
     const averageScore = scores && Object.keys(scores).length > 0
         ? Object.values(scores).reduce((sum, score) => sum + score, 0) / Object.keys(scores).length
         : null;
@@ -54,7 +57,7 @@ const StarterRow: React.FC<StarterRowProps> = (props) => {
                     {isByGameView ? null : <span className="hidden md:inline md:pl-1 lg:pl-2">{isHome ? 'vs.' : '@'}{'\t'}{oppTeam}</span>}
                 </p>
                 <div className='col-span-4'>
-                    {averageScore !== null && averageScore > 0.0 && (
+                    {averageScore !== null && averageScore > 0.0 && shouldShowAverageScore && (
                         <p className='text-[10px] lg:text-sm text-gray-400 mt-0.5 text-left'>
                             <span className='hidden sm:inline'>Average score: </span>
                             <span className='sm:hidden'>Avg. score: </span>

--- a/src/features/dashboard/timeslots/starters/TimeslotStarters.tsx
+++ b/src/features/dashboard/timeslots/starters/TimeslotStarters.tsx
@@ -39,7 +39,8 @@ const TimeslotStarters: React.FC<TimeslotStartersProps> = (props) => {
                             oppTeam={oppTeam}
                             isHome={isHome}
                             isUser={isUser}
-                            isByGameView={isByGameView} />
+                            isByGameView={isByGameView}
+                            scores={leagueInfo[starterId]?.leagues} />
                     );
                 })}
             </ul>

--- a/src/features/local-storage/local-storage.ts
+++ b/src/features/local-storage/local-storage.ts
@@ -13,6 +13,7 @@ export type UserData = {
     leagueIgnores?: LeagueIgnoresMap;
     leagueStarterSpots?: LeagueStarterSpots;
     shouldShowMissingStarters?: boolean;
+    shouldShowAverageScore?: boolean;
 }
 
 type CacheUserInfo = {
@@ -24,6 +25,7 @@ type CacheUserSettings = {
     leagueWeightsMap: LeagueWeightsMap;
     leagueIgnoresMap: LeagueIgnoresMap;
     shouldShowMissingStarters: boolean;
+    shouldShowAverageScore: boolean;
 }
 
 type CacheUserLeaguesInfo = {
@@ -74,7 +76,7 @@ export const safeUpdateLocalStorageData = (key: CacheKey, data: CacheValue) => {
 
 export const patchLocalStorageData = (key: CacheKey, data: CacheValue) => {
     const existingData = getLocalStorageData(key);
-    updateLocalStorageData(key, {...existingData, ...data});
+    updateLocalStorageData(key, { ...existingData, ...data });
 }
 
 // @TODO: change newData to CacheValue after user/id index page

--- a/src/features/settings/bi.ts
+++ b/src/features/settings/bi.ts
@@ -2,18 +2,20 @@ import { LeagueNamesMap, LeagueWeightsMap, LeagueIgnoresMap } from "../local-sto
 import * as gtag from '../../../lib/gtag';
 
 type LogSettingsSubmittedProps = {
-    leagueNames: LeagueNamesMap;
-    leagueWeightsMap: LeagueWeightsMap;
-    leagueIgnoresMap: LeagueIgnoresMap;
-    shouldShowMissingStarters: boolean;
-  }
+  leagueNames: LeagueNamesMap;
+  leagueWeightsMap: LeagueWeightsMap;
+  leagueIgnoresMap: LeagueIgnoresMap;
+  shouldShowMissingStarters: boolean;
+  shouldShowAverageScore: boolean;
+}
 export const logSettingsSubmitted = (settingsProps: LogSettingsSubmittedProps) => gtag.submitEvent({
   category: 'settings',
   label: 'submit',
   leagues_count: Object.keys(settingsProps.leagueNames).length,
   ignored_leagues: Object.values(settingsProps.leagueIgnoresMap).filter(check => !check).length,
   weighted_leagues: Object.values(settingsProps.leagueWeightsMap).filter(weight => weight > 0).length,
-  show_missing_starters: settingsProps.shouldShowMissingStarters
+  show_missing_starters: settingsProps.shouldShowMissingStarters,
+  show_average_scores: settingsProps.shouldShowAverageScore
 })
 
 export const logSettingsSkipped = () => gtag.submitEvent({

--- a/src/features/settings/useSettings.ts
+++ b/src/features/settings/useSettings.ts
@@ -10,11 +10,13 @@ export const useSettings = (leagues: SleeperLeagueData[]) => {
     const [leagueWeightsMap, setLeagueWeightsMap] = useState<LeagueWeightsMap>(cachedSettingsStatus === CacheStatus.HIT ? cachedSettings!.leagueWeightsMap : {});
     const [leagueIgnoresMap, setLeagueIgnoresMap] = useState<LeagueIgnoresMap>(cachedSettingsStatus === CacheStatus.HIT ? cachedSettings!.leagueIgnoresMap : {});
     const [shouldShowMissingStarters, setShouldShowMissingStarters] = useState<boolean>(cachedSettingsStatus === CacheStatus.HIT ? cachedSettings!.shouldShowMissingStarters : true);
+    const [shouldShowAverageScore, setShouldShowAverageScore] = useState<boolean>(cachedSettingsStatus === CacheStatus.HIT ? cachedSettings!.shouldShowAverageScore : true);
     useEffect(() => {
         if (cachedSettingsStatus === CacheStatus.HIT && cachedSettings) {
             setLeagueWeightsMap(cachedSettings.leagueWeightsMap);
             setLeagueIgnoresMap(cachedSettings.leagueIgnoresMap);
             setShouldShowMissingStarters(cachedSettings.shouldShowMissingStarters);
+            setShouldShowAverageScore(cachedSettings.shouldShowAverageScore);
         }
     }, [cachedSettingsStatus]);
 
@@ -26,23 +28,29 @@ export const useSettings = (leagues: SleeperLeagueData[]) => {
     }, [leagues])
 
     const onChangeLeagueWeight = (leagueId: string, weight: number) => {
-        setLeagueWeightsMap(currentMap => ({...currentMap, [leagueId]: weight}));
+        setLeagueWeightsMap(currentMap => ({ ...currentMap, [leagueId]: weight }));
     }
 
     const onChangeLeagueIgnore = (leagueId: string, shouldShow: boolean) => {
-        setLeagueIgnoresMap(currentMap => ({...currentMap, [leagueId]: shouldShow}));
+        setLeagueIgnoresMap(currentMap => ({ ...currentMap, [leagueId]: shouldShow }));
     }
 
     const onChangeShowMissingStarters = (shouldShow: boolean) => {
         setShouldShowMissingStarters(shouldShow);
     }
 
+    const onChangeShowAverageScore = (shouldShow: boolean) => {
+        setShouldShowAverageScore(shouldShow);
+    }
+
     return {
         leagueIgnoresMap,
         leagueWeightsMap,
         shouldShowMissingStarters,
+        shouldShowAverageScore,
         onChangeLeagueIgnore,
         onChangeLeagueWeight,
-        onChangeShowMissingStarters
+        onChangeShowMissingStarters,
+        onChangeShowAverageScore
     };
 };

--- a/src/pages/user/[id]/settings.tsx
+++ b/src/pages/user/[id]/settings.tsx
@@ -17,8 +17,8 @@ type UserDashboardPageProps = InferGetServerSidePropsType<typeof getServerSidePr
 const UserDashboardPage = ({ leagues }: UserDashboardPageProps) => {
     const router = useRouter();
     const { id, fromLogin } = router.query;
-    const { leagueIgnoresMap, leagueWeightsMap, shouldShowMissingStarters,
-        onChangeLeagueIgnore, onChangeLeagueWeight, onChangeShowMissingStarters } = useSettings(leagues);
+    const { leagueIgnoresMap, leagueWeightsMap, shouldShowMissingStarters, shouldShowAverageScore,
+        onChangeLeagueIgnore, onChangeLeagueWeight, onChangeShowMissingStarters, onChangeShowAverageScore } = useSettings(leagues);
 
     // move outside of component
     const submitWeightsHandler = (isSkipped = false) => {
@@ -29,6 +29,7 @@ const UserDashboardPage = ({ leagues }: UserDashboardPageProps) => {
         }, {})
         safeUpdateLocalStorageData('settings', {
             shouldShowMissingStarters,
+            shouldShowAverageScore,
             leagueIgnoresMap,
             leagueWeightsMap
         });
@@ -39,7 +40,7 @@ const UserDashboardPage = ({ leagues }: UserDashboardPageProps) => {
         if (isSkipped) {
             bi.logSettingsSkipped();
         } else {
-            bi.logSettingsSubmitted({ leagueNames, leagueWeightsMap, leagueIgnoresMap, shouldShowMissingStarters })
+            bi.logSettingsSubmitted({ leagueNames, leagueWeightsMap, leagueIgnoresMap, shouldShowMissingStarters, shouldShowAverageScore })
         }
         router.replace(`/user/${id}`);
     };
@@ -84,6 +85,15 @@ const UserDashboardPage = ({ leagues }: UserDashboardPageProps) => {
                                         onChange={event => onChangeShowMissingStarters(event.target.checked)} />
                                     <label htmlFor='missing_players_checkbox'
                                         className="text-primary-text text-sm pl-5 md:text-base">Show missing starters notice</label>
+                                </div>
+                                <div className='flex mt-3 mb-6'>
+                                    <input type='checkbox'
+                                        id='average_score_checkbox'
+                                        className='w-4 checked:accent-alt rounded-lg md:w-5'
+                                        checked={shouldShowAverageScore}
+                                        onChange={event => onChangeShowAverageScore(event.target.checked)} />
+                                    <label htmlFor='average_score_checkbox'
+                                        className="text-primary-text text-sm pl-5 md:text-base">Show average scores</label>
                                 </div>
                                 <button className="text-primary-text rounded-lg bg-alt w-full py-3"
                                     onClick={() => submitWeightsHandler(false)}>


### PR DESCRIPTION
Improve visibility of current performance of each player by adding his average score (pending on your/opp leagues) directly on the dashboard page.