### PR TITLE
Add Mock drafts feature

### DIFF
--- a/src/features/dashboard/bi.ts
+++ b/src/features/dashboard/bi.ts
@@ -5,9 +5,19 @@ export const logHomeLinkClicked = () => gtag.clickEvent({
     label: 'home'
 });
 
+export const logDashboardLinkClicked = () => gtag.clickEvent({
+    category: 'mock_drafts_screen_navbar',
+    label: 'dashboard'
+});
+
 export const logSettingsLinkClicked = () => gtag.clickEvent({
     category: 'home_screen_navbar',
     label: 'settings'
+});
+
+export const logMockDraftsLinkClicked = () => gtag.clickEvent({
+    category: 'home_screen_navbar',
+    label: 'mock_drafts'
 });
 
 export const logStarterClicked = () => gtag.clickEvent({

--- a/src/features/local-storage/hooks.ts
+++ b/src/features/local-storage/hooks.ts
@@ -3,11 +3,11 @@ import { getLocalStorageData } from "./local-storage";
 import { CacheStatus } from "./local-storage.types";
 import type { Cache } from './local-storage';
 
-export const useGetLocalStorage = <K extends keyof Cache>(key: K): {data: Cache[K] | undefined; cacheStatus: CacheStatus; clear: () => void} => {
+export const useGetLocalStorage = <K extends keyof Cache>(key: K): {data: Cache[K] | undefined; cacheStatus: CacheStatus; clear: () => void; refetch: () => void} => {
     const [cacheStatus, setCacheStatus] = useState(CacheStatus.LOADING);
     const [data, setData] = useState<Cache[typeof key]>();
 
-    useEffect(() => {
+    const fetchData = () => {
         try {
             const data = getLocalStorageData(key);
             if (data) {
@@ -23,11 +23,13 @@ export const useGetLocalStorage = <K extends keyof Cache>(key: K): {data: Cache[
             console.error(`Error fetching ${key} from cache:`, error);
             setCacheStatus(CacheStatus.MISS);
         }
-    }, [])
+    }
+
+    useEffect(fetchData, [])
 
     const clear = () => {
         setCacheStatus(CacheStatus.MISS);
     }
 
-    return {cacheStatus, data, clear};
+    return {cacheStatus, data, clear, refetch: fetchData};
 }

--- a/src/features/local-storage/local-storage.ts
+++ b/src/features/local-storage/local-storage.ts
@@ -4,18 +4,6 @@ export type LeagueIgnoresMap = { [key: string]: boolean };
 export type LeagueNamesMap = { [key: string]: string };
 export type LeagueStarterSpots = { [key: string]: number };
 
-export type UserData = {
-    sleeperId?: string;
-    username?: string;
-    leagueWeights?: LeagueWeightsMap;
-    leagueRosterIds?: LeagueRosterIdsMap;
-    leagueNames?: LeagueNamesMap;
-    leagueIgnores?: LeagueIgnoresMap;
-    leagueStarterSpots?: LeagueStarterSpots;
-    shouldShowMissingStarters?: boolean;
-    shouldShowAverageScore?: boolean;
-}
-
 type CacheUserInfo = {
     sleeperId?: string;
     username?: string;
@@ -34,10 +22,15 @@ type CacheUserLeaguesInfo = {
     leagueRosterIds?: LeagueRosterIdsMap;
 }
 
+type CacheUserMockDrafts = {
+    [key: string]: string; //@TODO: use a more specific type for the mock draft entity
+}
+
 export type Cache = {
     settings: CacheUserSettings;
     user: CacheUserInfo;
     leaguesInfo: CacheUserLeaguesInfo;
+    mockDrafts: CacheUserMockDrafts;
 }
 
 type CacheKey = keyof Cache;

--- a/src/features/mock-drafts/components/AddMockDraftForm.tsx
+++ b/src/features/mock-drafts/components/AddMockDraftForm.tsx
@@ -1,0 +1,26 @@
+interface AddMockDraftFormProps {
+    onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+    isCompact?: boolean;
+}
+
+const AddMockDraftForm = ({ onSubmit, isCompact }: AddMockDraftFormProps) => {
+    return (
+        <form
+            onSubmit={onSubmit}
+            className={`flex flex-col space-y-3 bg-accent rounded-lg ${isCompact ? 'px-5 py-4' : 'px-6 py-8'}`}
+        >
+            <input
+                className="p-3 text-base text-grey-600 border-[3px] border-solid border-grey-300 transition ease-in-out focus:text-primary focus:border-accent focus:outline-none md:text-md"
+                type="url"
+                name="mockDraftUrl"
+                placeholder="Enter the URL of the mock draft"
+                required
+            />
+            <button type="submit" className="bg-alt text-primary-text px-4 py-2 rounded-lg font-semibold tracking-wide">
+                Add Mock Draft
+            </button>
+        </form>
+    );
+};
+
+export default AddMockDraftForm;

--- a/src/features/mock-drafts/components/AddMockDraftModal.tsx
+++ b/src/features/mock-drafts/components/AddMockDraftModal.tsx
@@ -1,0 +1,41 @@
+import AddMockDraftForm from "./AddMockDraftForm";
+
+interface AddMockDraftModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+}
+
+const AddMockDraftModal = ({ isOpen, onClose, onSubmit }: AddMockDraftModalProps) => {
+    if (!isOpen) return null;
+
+    const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        onSubmit(e);
+        onClose();
+    };
+
+    return (
+        <div className="fixed inset-0 z-50 overflow-y-auto">
+            <div className="fixed inset-0 w-full h-full bg-black opacity-40" onClick={onClose} />
+            <div className="flex min-h-screen items-start justify-center p-4 pt-24 md:pt-32">
+                <div className="relative w-full max-w-md bg-primary rounded-lg p-4 md:p-6 shadow-lg">
+                    <button
+                        type="button"
+                        className="text-primary-text text-2xl absolute top-3 right-4"
+                        onClick={onClose}
+                        aria-label="Close"
+                    >
+                        &times;
+                    </button>
+                    <h2 className="text-primary-text text-lg font-semibold mb-4 pr-8">Add Mock Draft</h2>
+                    <p className="text-primary-text text-sm text-gray-400 mb-4">
+                        Paste a Sleeper mock draft URL to save it for future use.
+                    </p>
+                    <AddMockDraftForm onSubmit={handleSubmit} isCompact />
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default AddMockDraftModal;

--- a/src/features/mock-drafts/components/MockDraftCategoryDropdown.tsx
+++ b/src/features/mock-drafts/components/MockDraftCategoryDropdown.tsx
@@ -1,0 +1,45 @@
+import DashboardDropdown from "@/features/dashboard/filters/DashboardDropdown";
+import DashboardDropdownItem from "@/features/dashboard/filters/DashboardDropdownItem";
+import type { DraftCategory } from "../mock-drafts.types";
+import { formatDraftCategoryLabel } from "../extractors";
+
+interface MockDraftCategoryDropdownProps {
+    categories: DraftCategory[];
+    selectedCategory: DraftCategory;
+    onSelectCategory: (category: DraftCategory) => void;
+    isOpen: boolean;
+    toggleDropdown: () => void;
+}
+
+const MockDraftCategoryDropdown = ({
+    categories,
+    selectedCategory,
+    onSelectCategory,
+    isOpen,
+    toggleDropdown,
+}: MockDraftCategoryDropdownProps) => {
+    return (
+        <DashboardDropdown
+            isOpen={isOpen}
+            placeholder="Draft type"
+            toggleDropdown={toggleDropdown}
+            currentValue={formatDraftCategoryLabel(selectedCategory)}
+        >
+            <ul className="py-1 divide-y divide-secondary-accent" aria-labelledby="dropdown_category">
+                {categories.map(category => (
+                    <DashboardDropdownItem
+                        key={category}
+                        label={formatDraftCategoryLabel(category)}
+                        isSelected={category === selectedCategory}
+                        onClick={() => {
+                            onSelectCategory(category);
+                            toggleDropdown();
+                        }}
+                    />
+                ))}
+            </ul>
+        </DashboardDropdown>
+    );
+};
+
+export default MockDraftCategoryDropdown;

--- a/src/features/mock-drafts/components/MockDraftOrderDropdown.tsx
+++ b/src/features/mock-drafts/components/MockDraftOrderDropdown.tsx
@@ -1,0 +1,47 @@
+import DashboardDropdown from "@/features/dashboard/filters/DashboardDropdown";
+import DashboardDropdownItem from "@/features/dashboard/filters/DashboardDropdownItem";
+import type { DraftOrderFilter } from "../extractors";
+import { formatDraftOrderFilterLabel } from "../extractors";
+
+interface MockDraftOrderDropdownProps {
+    draftOrders: number[];
+    selectedDraftOrder: DraftOrderFilter;
+    onSelectDraftOrder: (draftOrder: DraftOrderFilter) => void;
+    isOpen: boolean;
+    toggleDropdown: () => void;
+}
+
+const MockDraftOrderDropdown = ({
+    draftOrders,
+    selectedDraftOrder,
+    onSelectDraftOrder,
+    isOpen,
+    toggleDropdown,
+}: MockDraftOrderDropdownProps) => {
+    const options: DraftOrderFilter[] = ['all', ...draftOrders];
+
+    return (
+        <DashboardDropdown
+            isOpen={isOpen}
+            placeholder="Draft slot"
+            toggleDropdown={toggleDropdown}
+            currentValue={formatDraftOrderFilterLabel(selectedDraftOrder)}
+        >
+            <ul className="py-1 divide-y divide-secondary-accent" aria-labelledby="dropdown_draft_order">
+                {options.map(option => (
+                    <DashboardDropdownItem
+                        key={option}
+                        label={formatDraftOrderFilterLabel(option)}
+                        isSelected={option === selectedDraftOrder}
+                        onClick={() => {
+                            onSelectDraftOrder(option);
+                            toggleDropdown();
+                        }}
+                    />
+                ))}
+            </ul>
+        </DashboardDropdown>
+    );
+};
+
+export default MockDraftOrderDropdown;

--- a/src/features/mock-drafts/components/MockDraftPickCell.tsx
+++ b/src/features/mock-drafts/components/MockDraftPickCell.tsx
@@ -16,7 +16,7 @@ const MockDraftPickCell = ({ pick }: MockDraftPickCellProps) => {
                 {position} · {team}
             </p>
             <p className="text-gray-500 text-[10px] sm:text-xs">
-                Pick {pick.pick_no}
+                Round {pick.round} · Pick {pick.pick_no}
             </p>
         </div>
     );

--- a/src/features/mock-drafts/components/MockDraftPickCell.tsx
+++ b/src/features/mock-drafts/components/MockDraftPickCell.tsx
@@ -1,0 +1,25 @@
+import type { SleeperDraftPick } from "../mock-drafts.types";
+
+interface MockDraftPickCellProps {
+    pick: SleeperDraftPick;
+}
+
+const MockDraftPickCell = ({ pick }: MockDraftPickCellProps) => {
+    const { first_name, last_name, position, team } = pick.metadata;
+
+    return (
+        <div className="flex-shrink-0 w-28 sm:w-32 md:w-36 bg-accent rounded-lg p-3 flex flex-col gap-1">
+            <p className="text-primary-text text-xs sm:text-sm font-medium line-clamp-2">
+                {first_name} {last_name}
+            </p>
+            <p className="text-gray-400 text-xs">
+                {position} · {team}
+            </p>
+            <p className="text-gray-500 text-[10px] sm:text-xs">
+                Pick {pick.pick_no}
+            </p>
+        </div>
+    );
+};
+
+export default MockDraftPickCell;

--- a/src/features/mock-drafts/components/MockDraftPickCell.tsx
+++ b/src/features/mock-drafts/components/MockDraftPickCell.tsx
@@ -4,18 +4,35 @@ interface MockDraftPickCellProps {
     pick: SleeperDraftPick;
 }
 
+const getCellBackgroundColor = (pick: SleeperDraftPick) => {
+    switch (pick.metadata.position) {
+        case 'QB':
+            return 'bg-pink-400/70';
+        case 'WR':
+            return 'bg-sky-400/70';
+        case 'RB':
+            return 'bg-emerald-300/70';
+        case 'TE':
+            return 'bg-amber-400/70';
+        case 'DEF':
+            return 'bg-orange-700/70';
+        default:
+            return 'bg-accent'
+    }
+}
+
 const MockDraftPickCell = ({ pick }: MockDraftPickCellProps) => {
     const { first_name, last_name, position, team } = pick.metadata;
 
     return (
-        <div className="flex-shrink-0 w-28 sm:w-32 md:w-36 bg-accent rounded-lg p-3 flex flex-col gap-1">
+        <div className={`w-full min-w-0 rounded-lg p-3 flex flex-col gap-1 ${getCellBackgroundColor(pick)}`}>
             <p className="text-primary-text text-xs sm:text-sm font-medium line-clamp-2">
                 {first_name} {last_name}
             </p>
-            <p className="text-gray-400 text-xs">
+            <p className="text-xs">
                 {position} · {team}
             </p>
-            <p className="text-gray-500 text-[10px] sm:text-xs">
+            <p className="text-primary-text text-[10px] sm:text-xs">
                 Round {pick.round} · Pick {pick.pick_no}
             </p>
         </div>

--- a/src/features/mock-drafts/components/MockDraftsGrid.tsx
+++ b/src/features/mock-drafts/components/MockDraftsGrid.tsx
@@ -1,0 +1,52 @@
+import { Fragment } from "react";
+import type { CategoryDraft } from "../extractors";
+import { getUserPicks } from "../extractors";
+import MockDraftPickCell from "./MockDraftPickCell";
+
+interface MockDraftsGridProps {
+    drafts: CategoryDraft[];
+    sleeperUserId: string;
+    emptyMessage?: string;
+}
+
+const MockDraftsGrid = ({
+    drafts,
+    sleeperUserId,
+    emptyMessage = 'No drafts found for this draft slot.',
+}: MockDraftsGridProps) => {
+    const draftRows = drafts.map(draft => ({
+        draftId: draft.metadata.draft_id,
+        userPicks: getUserPicks(draft.picks, sleeperUserId),
+    }));
+    const maxPicks = Math.max(...draftRows.map(row => row.userPicks.length), 0);
+
+    if (draftRows.length === 0) {
+        return (
+            <p className="text-gray-400 text-sm italic px-1">
+                {emptyMessage}
+            </p>
+        );
+    }
+
+    return (
+        <div className="overflow-auto max-h-[70vh] scrollbar-thin scrollbar-thumb-secondary-accent scrollbar-track-accent pb-2">
+            <div
+                className="grid gap-2 min-w-min"
+                style={{ gridTemplateColumns: `repeat(${maxPicks}, minmax(7rem, 7rem))` }}
+            >
+                {draftRows.map(({ draftId, userPicks }) => (
+                    <Fragment key={draftId}>
+                        {userPicks.map(pick => (
+                            <MockDraftPickCell key={`${draftId}-${pick.pick_no}`} pick={pick} />
+                        ))}
+                        {Array.from({ length: maxPicks - userPicks.length }).map((_, index) => (
+                            <div key={`${draftId}-empty-${index}`} aria-hidden="true" />
+                        ))}
+                    </Fragment>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export default MockDraftsGrid;

--- a/src/features/mock-drafts/components/MockDraftsGrid.tsx
+++ b/src/features/mock-drafts/components/MockDraftsGrid.tsx
@@ -32,7 +32,7 @@ const MockDraftsGrid = ({
         <div className="overflow-auto max-h-[70vh] scrollbar-thin scrollbar-thumb-secondary-accent scrollbar-track-accent pb-2">
             <div
                 className="grid gap-2 min-w-min"
-                style={{ gridTemplateColumns: `repeat(${maxPicks}, minmax(7rem, 7rem))` }}
+                style={{ gridTemplateColumns: `repeat(${maxPicks}, minmax(9rem, 9rem))` }}
             >
                 {draftRows.map(({ draftId, userPicks }) => (
                     <Fragment key={draftId}>

--- a/src/features/mock-drafts/components/MockDraftsList.tsx
+++ b/src/features/mock-drafts/components/MockDraftsList.tsx
@@ -71,10 +71,6 @@ const MockDraftsList = ({ mockDraftsByCategory, sleeperUserId }: MockDraftsListP
                 </div>
             </div>
 
-            <h2 className="text-primary-text text-xl md:text-2xl font-semibold tracking-wide">
-                {formatDraftCategoryLabel(selectedCategory)}
-            </h2>
-
             <div className="flex flex-col space-y-6">
                 {draftGroups.map(({ draftOrder, drafts }) => (
                     <div key={draftOrder ?? 'unknown'} className="flex flex-col space-y-2">

--- a/src/features/mock-drafts/components/MockDraftsList.tsx
+++ b/src/features/mock-drafts/components/MockDraftsList.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react";
+import type { DraftCategory, SleeperDraftMetadata, SleeperDraftPick } from "../mock-drafts.types";
+import { formatDraftCategoryLabel, formatOrdinalPick, getUserDraftSlot, getUserPicks } from "../extractors";
+import MockDraftCategoryDropdown from "./MockDraftCategoryDropdown";
+import MockDraftPickCell from "./MockDraftPickCell";
+
+type CategoryDraft = {
+    metadata: SleeperDraftMetadata;
+    picks: SleeperDraftPick[];
+};
+
+interface MockDraftsListProps {
+    mockDraftsByCategory: Record<DraftCategory, CategoryDraft[]>;
+    sleeperUserId: string;
+}
+
+const MockDraftsList = ({ mockDraftsByCategory, sleeperUserId }: MockDraftsListProps) => {
+    const categories = Object.keys(mockDraftsByCategory) as DraftCategory[];
+    const [selectedCategory, setSelectedCategory] = useState<DraftCategory>(() => categories[0]!);
+    const [isCategoryDropdownOpen, setIsCategoryDropdownOpen] = useState(false);
+
+    useEffect(() => {
+        if (categories.length > 0 && !categories.includes(selectedCategory)) {
+            setSelectedCategory(categories[0]!);
+        }
+    }, [categories, selectedCategory]);
+
+    if (categories.length === 0) return null;
+
+    const draftsInCategory = mockDraftsByCategory[selectedCategory] ?? [];
+
+    return (
+        <section className="flex flex-col w-full space-y-4">
+            <div className="w-full max-w-xs md:max-w-sm">
+                <MockDraftCategoryDropdown
+                    categories={categories}
+                    selectedCategory={selectedCategory}
+                    onSelectCategory={setSelectedCategory}
+                    isOpen={isCategoryDropdownOpen}
+                    toggleDropdown={() => setIsCategoryDropdownOpen(open => !open)}
+                />
+            </div>
+
+            <div className="flex flex-col space-y-2">
+                {draftsInCategory.map(draft => {
+                    const userPicks = getUserPicks(draft.picks, sleeperUserId);
+                    const draftSlot = getUserDraftSlot(draft.metadata, sleeperUserId);
+
+                    return (
+                        <div key={draft.metadata.draft_id} className="flex flex-col space-y-2">
+                            <div className="w-full py-1">
+                                <p className="text-gray-400 text-xs md:text-sm text-center tracking-wide">
+                                    {draftSlot ? formatOrdinalPick(draftSlot) : 'Draft slot unknown'}
+                                </p>
+                            </div>
+
+                            {userPicks.length > 0 ? (
+                                <div className="overflow-x-auto scrollbar-thin scrollbar-thumb-secondary-accent scrollbar-track-accent pb-2">
+                                    <div className="flex gap-2 min-w-min">
+                                        {userPicks.map(pick => (
+                                            <MockDraftPickCell key={pick.pick_no} pick={pick} />
+                                        ))}
+                                    </div>
+                                </div>
+                            ) : (
+                                <p className="text-gray-400 text-sm italic px-1">
+                                    No picks found for this user in this draft.
+                                </p>
+                            )}
+                        </div>
+                    );
+                })}
+            </div>
+        </section>
+    );
+};
+
+export default MockDraftsList;

--- a/src/features/mock-drafts/components/MockDraftsList.tsx
+++ b/src/features/mock-drafts/components/MockDraftsList.tsx
@@ -1,13 +1,15 @@
-import { useEffect, useState } from "react";
-import type { DraftCategory, SleeperDraftMetadata, SleeperDraftPick } from "../mock-drafts.types";
-import { formatDraftCategoryLabel, formatOrdinalPick, getUserDraftSlot, getUserPicks } from "../extractors";
+import { useEffect, useMemo, useState } from "react";
+import type { DraftCategory } from "../mock-drafts.types";
+import type { DraftOrderFilter, CategoryDraft } from "../extractors";
+import {
+    formatDraftCategoryLabel,
+    formatOrdinalPick,
+    getDraftOrdersInCategory,
+    groupDraftsByDraftOrder,
+} from "../extractors";
 import MockDraftCategoryDropdown from "./MockDraftCategoryDropdown";
-import MockDraftPickCell from "./MockDraftPickCell";
-
-type CategoryDraft = {
-    metadata: SleeperDraftMetadata;
-    picks: SleeperDraftPick[];
-};
+import MockDraftOrderDropdown from "./MockDraftOrderDropdown";
+import MockDraftsGrid from "./MockDraftsGrid";
 
 interface MockDraftsListProps {
     mockDraftsByCategory: Record<DraftCategory, CategoryDraft[]>;
@@ -17,7 +19,9 @@ interface MockDraftsListProps {
 const MockDraftsList = ({ mockDraftsByCategory, sleeperUserId }: MockDraftsListProps) => {
     const categories = Object.keys(mockDraftsByCategory) as DraftCategory[];
     const [selectedCategory, setSelectedCategory] = useState<DraftCategory>(() => categories[0]!);
+    const [selectedDraftOrder, setSelectedDraftOrder] = useState<DraftOrderFilter>('all');
     const [isCategoryDropdownOpen, setIsCategoryDropdownOpen] = useState(false);
+    const [isDraftOrderDropdownOpen, setIsDraftOrderDropdownOpen] = useState(false);
 
     useEffect(() => {
         if (categories.length > 0 && !categories.includes(selectedCategory)) {
@@ -25,51 +29,63 @@ const MockDraftsList = ({ mockDraftsByCategory, sleeperUserId }: MockDraftsListP
         }
     }, [categories, selectedCategory]);
 
-    if (categories.length === 0) return null;
+    useEffect(() => {
+        setSelectedDraftOrder('all');
+    }, [selectedCategory]);
 
     const draftsInCategory = mockDraftsByCategory[selectedCategory] ?? [];
+    const draftOrdersInCategory = useMemo(
+        () => getDraftOrdersInCategory(draftsInCategory, sleeperUserId),
+        [draftsInCategory, sleeperUserId],
+    );
+
+    const draftGroups = useMemo(
+        () => groupDraftsByDraftOrder(draftsInCategory, sleeperUserId, selectedDraftOrder),
+        [draftsInCategory, sleeperUserId, selectedDraftOrder],
+    );
+
+    if (categories.length === 0) return null;
+
+    const showDraftOrderHeaders = selectedDraftOrder === 'all';
 
     return (
         <section className="flex flex-col w-full space-y-4">
-            <div className="w-full max-w-xs md:max-w-sm">
-                <MockDraftCategoryDropdown
-                    categories={categories}
-                    selectedCategory={selectedCategory}
-                    onSelectCategory={setSelectedCategory}
-                    isOpen={isCategoryDropdownOpen}
-                    toggleDropdown={() => setIsCategoryDropdownOpen(open => !open)}
-                />
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start w-full max-w-2xl">
+                <div className="w-full max-w-xs md:max-w-sm">
+                    <MockDraftCategoryDropdown
+                        categories={categories}
+                        selectedCategory={selectedCategory}
+                        onSelectCategory={setSelectedCategory}
+                        isOpen={isCategoryDropdownOpen}
+                        toggleDropdown={() => setIsCategoryDropdownOpen(open => !open)}
+                    />
+                </div>
+                <div className="w-full max-w-xs md:max-w-sm">
+                    <MockDraftOrderDropdown
+                        draftOrders={draftOrdersInCategory}
+                        selectedDraftOrder={selectedDraftOrder}
+                        onSelectDraftOrder={setSelectedDraftOrder}
+                        isOpen={isDraftOrderDropdownOpen}
+                        toggleDropdown={() => setIsDraftOrderDropdownOpen(open => !open)}
+                    />
+                </div>
             </div>
 
-            <div className="flex flex-col space-y-2">
-                {draftsInCategory.map(draft => {
-                    const userPicks = getUserPicks(draft.picks, sleeperUserId);
-                    const draftSlot = getUserDraftSlot(draft.metadata, sleeperUserId);
+            <h2 className="text-primary-text text-xl md:text-2xl font-semibold tracking-wide">
+                {formatDraftCategoryLabel(selectedCategory)}
+            </h2>
 
-                    return (
-                        <div key={draft.metadata.draft_id} className="flex flex-col space-y-2">
-                            <div className="w-full py-1">
-                                <p className="text-gray-400 text-xs md:text-sm text-center tracking-wide">
-                                    {draftSlot ? formatOrdinalPick(draftSlot) : 'Draft slot unknown'}
-                                </p>
-                            </div>
-
-                            {userPicks.length > 0 ? (
-                                <div className="overflow-x-auto scrollbar-thin scrollbar-thumb-secondary-accent scrollbar-track-accent pb-2">
-                                    <div className="flex gap-2 min-w-min">
-                                        {userPicks.map(pick => (
-                                            <MockDraftPickCell key={pick.pick_no} pick={pick} />
-                                        ))}
-                                    </div>
-                                </div>
-                            ) : (
-                                <p className="text-gray-400 text-sm italic px-1">
-                                    No picks found for this user in this draft.
-                                </p>
-                            )}
-                        </div>
-                    );
-                })}
+            <div className="flex flex-col space-y-6">
+                {draftGroups.map(({ draftOrder, drafts }) => (
+                    <div key={draftOrder ?? 'unknown'} className="flex flex-col space-y-2">
+                        {showDraftOrderHeaders && (
+                            <p className="text-gray-400 text-xs md:text-sm text-center tracking-wide">
+                                {draftOrder ? formatOrdinalPick(draftOrder) : 'Draft slot unknown'}
+                            </p>
+                        )}
+                        <MockDraftsGrid drafts={drafts} sleeperUserId={sleeperUserId} />
+                    </div>
+                ))}
             </div>
         </section>
     );

--- a/src/features/mock-drafts/components/MockDraftsList.tsx
+++ b/src/features/mock-drafts/components/MockDraftsList.tsx
@@ -23,16 +23,6 @@ const MockDraftsList = ({ mockDraftsByCategory, sleeperUserId }: MockDraftsListP
     const [isCategoryDropdownOpen, setIsCategoryDropdownOpen] = useState(false);
     const [isDraftOrderDropdownOpen, setIsDraftOrderDropdownOpen] = useState(false);
 
-    useEffect(() => {
-        if (categories.length > 0 && !categories.includes(selectedCategory)) {
-            setSelectedCategory(categories[0]!);
-        }
-    }, [categories, selectedCategory]);
-
-    useEffect(() => {
-        setSelectedDraftOrder('all');
-    }, [selectedCategory]);
-
     const draftsInCategory = mockDraftsByCategory[selectedCategory] ?? [];
     const draftOrdersInCategory = useMemo(
         () => getDraftOrdersInCategory(draftsInCategory, sleeperUserId),

--- a/src/features/mock-drafts/components/MockDraftsList.tsx
+++ b/src/features/mock-drafts/components/MockDraftsList.tsx
@@ -50,7 +50,7 @@ const MockDraftsList = ({ mockDraftsByCategory, sleeperUserId }: MockDraftsListP
 
     return (
         <section className="flex flex-col w-full space-y-4">
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-start w-full max-w-2xl">
+            <div className="flex flex-col gap-3 w-full max-w-2xl">
                 <div className="w-full max-w-xs md:max-w-sm">
                     <MockDraftCategoryDropdown
                         categories={categories}

--- a/src/features/mock-drafts/data.ts
+++ b/src/features/mock-drafts/data.ts
@@ -1,12 +1,27 @@
 import { fetcher } from "@/utils/fetcher"
+import type { SleeperDraftPick, SleeperDraftMetadata } from "./mock-drafts.types";
 
-type SleeperDraft = {
-    start_time: number;
-    draft_id: string;
+const getMockDraftsPicksData = async (mockDraftIds: string[]): Promise<SleeperDraftPick[][]> => {
+    const draftPicksPromises = mockDraftIds.map(mockDraftId => fetcher(`https://api.sleeper.app/v1/draft/${mockDraftId}/picks`));
+    const draftPicks = await Promise.all(draftPicksPromises);
+    return draftPicks;
 }
 
-export const getMockDraftsData = async (mockDraftIds: string[]): Promise<SleeperDraft[]> => {
+const getMockDraftsData = async (mockDraftIds: string[]): Promise<SleeperDraftMetadata[]> => {
     const draftsPromises = mockDraftIds.map(mockDraftId => fetcher(`https://api.sleeper.app/v1/draft/${mockDraftId}`));
     const drafts = await Promise.all(draftsPromises);
     return drafts;
+}
+
+export const getMockDrafts = async (mockDraftIds: string[]) => {
+    const [drafts, draftPicks] = await Promise.all([getMockDraftsData(mockDraftIds), getMockDraftsPicksData(mockDraftIds)]);
+    return mockDraftIds.reduce((acc, mockDraftId, index) => {
+        return {
+            ...acc,
+            [mockDraftId]: {
+                metadata: drafts[index],
+                picks: draftPicks[index] ?? [],
+            }
+        }
+    }, {} as Record<string, {metadata: SleeperDraftMetadata | undefined, picks: SleeperDraftPick[]}>);
 }

--- a/src/features/mock-drafts/data.ts
+++ b/src/features/mock-drafts/data.ts
@@ -1,0 +1,12 @@
+import { fetcher } from "@/utils/fetcher"
+
+type SleeperDraft = {
+    start_time: number;
+    draft_id: string;
+}
+
+export const getMockDraftsData = async (mockDraftIds: string[]): Promise<SleeperDraft[]> => {
+    const draftsPromises = mockDraftIds.map(mockDraftId => fetcher(`https://api.sleeper.app/v1/draft/${mockDraftId}`));
+    const drafts = await Promise.all(draftsPromises);
+    return drafts;
+}

--- a/src/features/mock-drafts/extractors.ts
+++ b/src/features/mock-drafts/extractors.ts
@@ -29,7 +29,7 @@ export const formatOrdinalPick = (pickNumber: number): string => {
 };
 
 export const getUserDraftSlot = (draftMetadata: SleeperDraftMetadata, sleeperUserId: string): number | undefined =>
-    draftMetadata.metadata.draft_order?.[sleeperUserId];
+    draftMetadata.draft_order?.[sleeperUserId];
 
 export const getUserPicks = (picks: SleeperDraftPick[], sleeperUserId: string): SleeperDraftPick[] =>
     picks

--- a/src/features/mock-drafts/extractors.ts
+++ b/src/features/mock-drafts/extractors.ts
@@ -36,6 +36,70 @@ export const getUserPicks = (picks: SleeperDraftPick[], sleeperUserId: string): 
         .filter(pick => pick.picked_by === sleeperUserId)
         .sort((a, b) => a.pick_no - b.pick_no);
 
+export const getDraftOrdersInCategory = (
+    drafts: { metadata: SleeperDraftMetadata }[],
+    sleeperUserId: string,
+): number[] => {
+    const draftOrders = new Set<number>();
+    for (const draft of drafts) {
+        const draftSlot = getUserDraftSlot(draft.metadata, sleeperUserId);
+        if (draftSlot !== undefined) {
+            draftOrders.add(draftSlot);
+        }
+    }
+    return Array.from(draftOrders).sort((a, b) => a - b);
+};
+
+export type DraftOrderFilter = 'all' | number;
+
+export const formatDraftOrderFilterLabel = (filter: DraftOrderFilter): string =>
+    filter === 'all' ? 'All Picks' : formatOrdinalPick(filter);
+
+export type CategoryDraft = {
+    metadata: SleeperDraftMetadata;
+    picks: SleeperDraftPick[];
+};
+
+export type DraftOrderGroup = {
+    draftOrder: number | undefined;
+    drafts: CategoryDraft[];
+};
+
+export const groupDraftsByDraftOrder = (
+    drafts: CategoryDraft[],
+    sleeperUserId: string,
+    draftOrderFilter: DraftOrderFilter = 'all',
+): DraftOrderGroup[] => {
+    const filteredDrafts = draftOrderFilter === 'all'
+        ? drafts
+        : drafts.filter(draft => getUserDraftSlot(draft.metadata, sleeperUserId) === draftOrderFilter);
+
+    const groups = new Map<number | 'unknown', CategoryDraft[]>();
+    for (const draft of filteredDrafts) {
+        const draftSlot = getUserDraftSlot(draft.metadata, sleeperUserId);
+        const groupKey = draftSlot ?? 'unknown';
+        const existing = groups.get(groupKey) ?? [];
+        existing.push(draft);
+        groups.set(groupKey, existing);
+    }
+
+    const knownDraftOrders = Array.from(groups.keys())
+        .filter((key): key is number => key !== 'unknown')
+        .sort((a, b) => a - b);
+
+    const draftOrderGroups: DraftOrderGroup[] = knownDraftOrders.map(draftOrder => ({
+        draftOrder,
+        drafts: groups.get(draftOrder)!,
+    }));
+
+    const unknownDrafts = groups.get('unknown');
+    if (unknownDrafts) {
+        draftOrderGroups.push({ draftOrder: undefined, drafts: unknownDrafts });
+    }
+
+    return draftOrderGroups;
+};
+
 const extractDraftCategory = (draftMetadata: SleeperDraftMetadata | undefined): DraftCategory | undefined => {
     if (!draftMetadata) return draftMetadata;
     return `${draftMetadata.metadata.scoring_type}-${draftMetadata.settings.teams}-${draftMetadata.settings.slots_qb}-${draftMetadata.settings.slots_wr}`

--- a/src/features/mock-drafts/extractors.ts
+++ b/src/features/mock-drafts/extractors.ts
@@ -1,5 +1,41 @@
 import type { DraftCategory, SleeperDraftMetadata, SleeperDraftPick } from "./mock-drafts.types";
 
+const SCORING_TYPE_LABELS: Record<SleeperDraftMetadata['metadata']['scoring_type'], string> = {
+    standard: 'Standard',
+    half_ppr: 'Half PPR',
+    ppr: 'PPR',
+};
+
+export const formatDraftCategoryLabel = (category: DraftCategory): string => {
+    const [scoringType, teams, slotsQb, slotsWr] = category.split('-');
+    const scoringLabel = SCORING_TYPE_LABELS[scoringType as SleeperDraftMetadata['metadata']['scoring_type']] ?? scoringType;
+    const wrCount = Number(slotsWr);
+    const wrLabel = `${slotsWr}WR${wrCount > 1 ? 's' : ''}`;
+    return `${scoringLabel}, ${teams} team, ${slotsQb}QB, ${wrLabel}`;
+};
+
+export const formatOrdinalPick = (pickNumber: number): string => {
+    const mod100 = pickNumber % 100;
+    const suffix = mod100 >= 11 && mod100 <= 13
+        ? 'th'
+        : pickNumber % 10 === 1
+            ? 'st'
+            : pickNumber % 10 === 2
+                ? 'nd'
+                : pickNumber % 10 === 3
+                    ? 'rd'
+                    : 'th';
+    return `${pickNumber}${suffix} pick`;
+};
+
+export const getUserDraftSlot = (draftMetadata: SleeperDraftMetadata, sleeperUserId: string): number | undefined =>
+    draftMetadata.metadata.draft_order?.[sleeperUserId];
+
+export const getUserPicks = (picks: SleeperDraftPick[], sleeperUserId: string): SleeperDraftPick[] =>
+    picks
+        .filter(pick => pick.picked_by === sleeperUserId)
+        .sort((a, b) => a.pick_no - b.pick_no);
+
 const extractDraftCategory = (draftMetadata: SleeperDraftMetadata | undefined): DraftCategory | undefined => {
     if (!draftMetadata) return draftMetadata;
     return `${draftMetadata.metadata.scoring_type}-${draftMetadata.settings.teams}-${draftMetadata.settings.slots_qb}-${draftMetadata.settings.slots_wr}`
@@ -10,7 +46,7 @@ export const categorizeMockDraftsByDraftType = (drafts: Record<string, {
     picks: SleeperDraftPick[];
 }> | undefined) => {
     if (!drafts) return {};
-    
+
     const mockDraftsByCategory: Record<DraftCategory, {
         metadata: SleeperDraftMetadata;
         picks: SleeperDraftPick[];
@@ -19,8 +55,9 @@ export const categorizeMockDraftsByDraftType = (drafts: Record<string, {
         const draftCategory = extractDraftCategory(draft.metadata);
         if (draftCategory && draft.metadata) {
             const {metadata, picks} = draft;
-            if (mockDraftsByCategory[draftCategory]) {
-                mockDraftsByCategory[draftCategory].push({metadata, picks});
+            const existing = mockDraftsByCategory[draftCategory];
+            if (existing) {
+                existing.push({metadata, picks});
             } else {
                 mockDraftsByCategory[draftCategory] = [{metadata, picks}]
             }

--- a/src/features/mock-drafts/extractors.ts
+++ b/src/features/mock-drafts/extractors.ts
@@ -1,0 +1,30 @@
+import type { DraftCategory, SleeperDraftMetadata, SleeperDraftPick } from "./mock-drafts.types";
+
+const extractDraftCategory = (draftMetadata: SleeperDraftMetadata | undefined): DraftCategory | undefined => {
+    if (!draftMetadata) return draftMetadata;
+    return `${draftMetadata.metadata.scoring_type}-${draftMetadata.settings.teams}-${draftMetadata.settings.slots_qb}-${draftMetadata.settings.slots_wr}`
+}
+
+export const categorizeMockDraftsByDraftType = (drafts: Record<string, {
+    metadata: SleeperDraftMetadata | undefined;
+    picks: SleeperDraftPick[];
+}> | undefined) => {
+    if (!drafts) return {};
+    
+    const mockDraftsByCategory: Record<DraftCategory, {
+        metadata: SleeperDraftMetadata;
+        picks: SleeperDraftPick[];
+    }[]> = {};
+    for (let draft of Object.values(drafts)) {
+        const draftCategory = extractDraftCategory(draft.metadata);
+        if (draftCategory && draft.metadata) {
+            const {metadata, picks} = draft;
+            if (mockDraftsByCategory[draftCategory]) {
+                mockDraftsByCategory[draftCategory].push({metadata, picks});
+            } else {
+                mockDraftsByCategory[draftCategory] = [{metadata, picks}]
+            }
+        }
+    }
+    return mockDraftsByCategory;
+}

--- a/src/features/mock-drafts/hooks/useSleeperMockDraftsQuery.ts
+++ b/src/features/mock-drafts/hooks/useSleeperMockDraftsQuery.ts
@@ -1,0 +1,7 @@
+import { trpc } from "@/utils/trpc"
+
+export const useSleeperMockDraftsQuery = (mockDraftIds: string[]) => {
+    const {data: drafts, isLoading, isError} = trpc.useQuery(['sleeper-api.getMockDraftsData', {mockDraftIds}])
+
+    return {drafts, isLoading, isError}
+}

--- a/src/features/mock-drafts/mock-drafts.types.ts
+++ b/src/features/mock-drafts/mock-drafts.types.ts
@@ -3,6 +3,7 @@ export type SleeperDraftMetadata = {
     draft_id: string;
     metadata: {
         scoring_type: 'standard' | 'half_ppr' | 'ppr' //@TODO: add all types
+        draft_order?: Record<string, number>;
     },
     settings: {
         teams: number;

--- a/src/features/mock-drafts/mock-drafts.types.ts
+++ b/src/features/mock-drafts/mock-drafts.types.ts
@@ -1,9 +1,9 @@
 export type SleeperDraftMetadata = {
     start_time: number;
     draft_id: string;
+    draft_order?: Record<string, number>;
     metadata: {
         scoring_type: 'standard' | 'half_ppr' | 'ppr' //@TODO: add all types
-        draft_order?: Record<string, number>;
     },
     settings: {
         teams: number;

--- a/src/features/mock-drafts/mock-drafts.types.ts
+++ b/src/features/mock-drafts/mock-drafts.types.ts
@@ -1,0 +1,31 @@
+export type SleeperDraftMetadata = {
+    start_time: number;
+    draft_id: string;
+    metadata: {
+        scoring_type: 'standard' | 'half_ppr' | 'ppr' //@TODO: add all types
+    },
+    settings: {
+        teams: number;
+        slots_qb: number;
+        slots_wr: number;
+        slots_rb: number;
+        slots_te: number;
+    }
+}
+
+export type DraftCategory = `${SleeperDraftMetadata['metadata']['scoring_type']}-${SleeperDraftMetadata['settings']['teams']}-${SleeperDraftMetadata['settings']['slots_qb']}-${SleeperDraftMetadata['settings']['slots_wr']}`
+
+export type SleeperDraftPick = {
+    player_id: string;
+    picked_by: string;
+    pick_no: number;
+    draft_slot: number;
+    round: number;
+    metadata: {
+        team: string; //@TODO: we have enum for this?
+        first_name: string;
+        last_name: string;
+        number: string;
+        position: string //@TODO: we have enum for this?
+    }
+}

--- a/src/pages/user/[id]/index.tsx
+++ b/src/pages/user/[id]/index.tsx
@@ -57,6 +57,9 @@ const UserDashboardPage = (props: { nflWeek: WEEKS }) => {
                 <Link href="/" passHref >
                     <PageLogo title={'🏈 Sleepy'} onClick={bi.logHomeLinkClicked} />
                 </Link>
+                <Link href={`/user/${id}/mock-drafts`} >
+                    <button className='text-md text-primary-text font-semibold absolute top-5 right-28 md:right-32' onClick={bi.logMockDraftsLinkClicked}>🔮 Mock Drafts</button>
+                </Link>
                 <Link href={`/user/${id}/settings`} >
                     <button className='text-md text-primary-text font-semibold absolute top-5 right-5' onClick={bi.logSettingsLinkClicked}>⚙️ Settings</button>
                 </Link>

--- a/src/pages/user/[id]/mock-drafts.tsx
+++ b/src/pages/user/[id]/mock-drafts.tsx
@@ -46,10 +46,10 @@ const MockDraftsPage = () => {
     return (
         <>
             <AppHeader title={'Sleepy - Mock Drafts'} />
-            <main className={`flex flex-col p-4 pt-16 bg-primary w-full min-h-screen ${hasDrafts ? 'pb-8' : 'justify-center h-screen'}`}>
-                <Link href={`/user/${sleeperUserId}`} passHref >
-                    <PageLogo title={'🏈 Sleepy'} onClick={bi.logDashboardLinkClicked} />
-                </Link>
+            <Link href={`/user/${sleeperUserId}`} passHref >
+                <PageLogo title={'🏈 Sleepy'} onClick={bi.logDashboardLinkClicked} />
+            </Link>
+            <main className={`flex flex-col p-4 pt-16 bg-primary w-full min-h-screen ${hasDrafts ? 'pb-8' : 'h-screen'}`}>
 
                 <h1 className='text-primary-text text-3xl font-semibold text-left w-full'>🔮 Mock Drafts</h1>
                 {hasDrafts && (

--- a/src/pages/user/[id]/mock-drafts.tsx
+++ b/src/pages/user/[id]/mock-drafts.tsx
@@ -1,14 +1,26 @@
+import { useState } from "react";
+import { useRouter } from "next/router";
 import AppHeader from "@/components/layout/AppHeader";
 import PageLogo from "@/components/PageLogo";
+import Loader from "@/components/Loader";
 import { useGetLocalStorage } from "@/features/local-storage/hooks";
-import { patchLocalStorageData, setLocalStorageData, updateLocalStorageData } from "@/features/local-storage/local-storage";
+import { patchLocalStorageData, setLocalStorageData } from "@/features/local-storage/local-storage";
+import AddMockDraftForm from "@/features/mock-drafts/components/AddMockDraftForm";
+import AddMockDraftModal from "@/features/mock-drafts/components/AddMockDraftModal";
+import MockDraftsList from "@/features/mock-drafts/components/MockDraftsList";
 import { categorizeMockDraftsByDraftType } from "@/features/mock-drafts/extractors";
 import { useSleeperMockDraftsQuery } from "@/features/mock-drafts/hooks/useSleeperMockDraftsQuery";
 
 const MockDraftsPage = () => {
+    const router = useRouter();
+    const sleeperUserId = router.query.id as string;
+    const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+
     const { data: mockDrafts, refetch: refetchMockDrafts } = useGetLocalStorage("mockDrafts");
-    const { drafts } = useSleeperMockDraftsQuery(Object.keys(mockDrafts ?? {}));
+    const mockDraftIds = Object.keys(mockDrafts ?? {});
+    const { drafts, isLoading } = useSleeperMockDraftsQuery(mockDraftIds);
     const mockDraftsByCategory = categorizeMockDraftsByDraftType(drafts);
+    const hasDrafts = Object.keys(mockDraftsByCategory).length > 0;
 
     const addMockDraft = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
@@ -25,37 +37,67 @@ const MockDraftsPage = () => {
                 });
             }
             refetchMockDrafts();
+            (e.target as HTMLFormElement).reset();
         }
-    }
+    };
 
     return (
         <>
             <AppHeader title={'Sleepy - Mock Drafts'} />
-            <main className="flex flex-col items-center justify-center h-screen p-4 bg-primary">
+            <main className={`flex flex-col items-center p-4 pt-16 bg-primary w-full min-h-screen ${hasDrafts ? 'pb-8' : 'justify-center h-screen'}`}>
                 <PageLogo title={`⚙️ Mock Drafts`} />
-                <div className="flex flex-col w-full px-6 py-4 space-y-4">
-                    <p className='text-primary-text text-lg'>
-                        Add the URL of your mock draft to the form below to save it for future use.
-                    </p>
-                    <form onSubmit={addMockDraft} className="flex flex-col space-y-3 bg-accent py-8 px-6 rounded-lg">
-                        <input type="url" name="mockDraftUrl" placeholder="Enter the URL of the mock draft" />
-                        <button type="submit" className="bg-alt text-primary-text px-4 py-2 rounded-lg">Add Mock Draft</button>
-                    </form>
-                    <ul>
-                        {Object.entries(mockDraftsByCategory).map(([category, drafts]) => {
-                            const draftsNode = drafts.map(draft => {
-                                return <p key={draft.metadata.draft_id} className="ml-2">{draft.metadata.start_time}</p>
-                            })
-                            return <li className="text-primary-text">
-                                {category}
-                                {draftsNode}
-                            </li>
-                        })}
-                    </ul>
+
+                {hasDrafts && (
+                    <button
+                        type="button"
+                        className="text-primary-text font-semibold bg-alt rounded-lg px-4 py-2 absolute top-5 right-4 md:right-8 text-sm md:text-base"
+                        onClick={() => setIsAddModalOpen(true)}
+                    >
+                        + Add Mock Draft
+                    </button>
+                )}
+
+                <div className={`flex flex-col w-full max-w-5xl space-y-6 ${hasDrafts ? 'mt-8 md:mt-12 px-2 md:px-6' : 'px-6 py-4'}`}>
+                    {!hasDrafts && (
+                        <>
+                            <div className="text-center space-y-2 max-w-lg mx-auto">
+                                <p className="text-primary-text text-lg md:text-xl font-semibold">
+                                    No mock drafts yet
+                                </p>
+                                <p className="text-gray-400 text-sm md:text-base">
+                                    Add a Sleeper mock draft URL below to track your picks and compare drafts across formats.
+                                </p>
+                            </div>
+                            {isLoading && mockDraftIds.length > 0 ? (
+                                <Loader />
+                            ) : (
+                                <AddMockDraftForm onSubmit={addMockDraft} />
+                            )}
+                        </>
+                    )}
+
+                    {hasDrafts && (
+                        <>
+                            {isLoading ? (
+                                <Loader />
+                            ) : (
+                                <MockDraftsList
+                                    mockDraftsByCategory={mockDraftsByCategory}
+                                    sleeperUserId={sleeperUserId}
+                                />
+                            )}
+                        </>
+                    )}
                 </div>
+
+                <AddMockDraftModal
+                    isOpen={isAddModalOpen}
+                    onClose={() => setIsAddModalOpen(false)}
+                    onSubmit={addMockDraft}
+                />
             </main>
         </>
-    )
-}
+    );
+};
 
 export default MockDraftsPage;

--- a/src/pages/user/[id]/mock-drafts.tsx
+++ b/src/pages/user/[id]/mock-drafts.tsx
@@ -1,0 +1,53 @@
+import AppHeader from "@/components/layout/AppHeader";
+import PageLogo from "@/components/PageLogo";
+import { useGetLocalStorage } from "@/features/local-storage/hooks";
+import { patchLocalStorageData, setLocalStorageData, updateLocalStorageData } from "@/features/local-storage/local-storage";
+
+const MockDraftsPage = () => {
+    const { data: mockDrafts, refetch: refetchMockDrafts } = useGetLocalStorage("mockDrafts");
+
+    const addMockDraft = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        const formData = new FormData(e.target as HTMLFormElement);
+        const mockDraftUrl = formData.get("mockDraftUrl") as string;
+        const mockDraftId = mockDraftUrl.split("/").pop(); //@TODO: use Regex for better parsing.
+        if (mockDraftId) {
+            if (!mockDrafts) {
+                setLocalStorageData("mockDrafts", { [mockDraftId]: mockDraftUrl });
+            } else {
+                patchLocalStorageData("mockDrafts", {
+                    ...mockDrafts,
+                    [mockDraftId]: mockDraftUrl
+                });
+            }
+            refetchMockDrafts();
+        }
+    }
+
+    return (
+        <>
+            <AppHeader title={'Sleepy - Mock Drafts'} />
+            <main className="flex flex-col items-center justify-center h-screen p-4 bg-primary">
+                <PageLogo title={`⚙️ Mock Drafts`} />
+                <div className="flex flex-col w-full px-6 py-4 space-y-4">
+                    <p className='text-primary-text text-lg'>
+                        Add the URL of your mock draft to the form below to save it for future use.
+                    </p>
+                    <form onSubmit={addMockDraft} className="flex flex-col space-y-3 bg-accent py-8 px-6 rounded-lg">
+                        <input type="url" name="mockDraftUrl" placeholder="Enter the URL of the mock draft" />
+                        <button type="submit" className="bg-alt text-primary-text px-4 py-2 rounded-lg">Add Mock Draft</button>
+                    </form>
+                    <ul>
+                        {Object.entries(mockDrafts ?? {}).map(([draftId, draftUrl]) => {
+                            return (
+                                <li key={draftId} className="text-primary-text text-sm">{draftUrl}</li>
+                            )
+                        })}
+                    </ul>
+                </div>
+            </main>
+        </>
+    )
+}
+
+export default MockDraftsPage;

--- a/src/pages/user/[id]/mock-drafts.tsx
+++ b/src/pages/user/[id]/mock-drafts.tsx
@@ -10,6 +10,8 @@ import AddMockDraftModal from "@/features/mock-drafts/components/AddMockDraftMod
 import MockDraftsList from "@/features/mock-drafts/components/MockDraftsList";
 import { categorizeMockDraftsByDraftType } from "@/features/mock-drafts/extractors";
 import { useSleeperMockDraftsQuery } from "@/features/mock-drafts/hooks/useSleeperMockDraftsQuery";
+import Link from "next/link";
+import * as bi from '@/features/dashboard/bi';
 
 const MockDraftsPage = () => {
     const router = useRouter();
@@ -44,9 +46,12 @@ const MockDraftsPage = () => {
     return (
         <>
             <AppHeader title={'Sleepy - Mock Drafts'} />
-            <main className={`flex flex-col items-center p-4 pt-16 bg-primary w-full min-h-screen ${hasDrafts ? 'pb-8' : 'justify-center h-screen'}`}>
-                <PageLogo title={`⚙️ Mock Drafts`} />
+            <main className={`flex flex-col p-4 pt-16 bg-primary w-full min-h-screen ${hasDrafts ? 'pb-8' : 'justify-center h-screen'}`}>
+                <Link href={`/user/${sleeperUserId}`} passHref >
+                    <PageLogo title={'🏈 Sleepy'} onClick={bi.logDashboardLinkClicked} />
+                </Link>
 
+                <h1 className='text-primary-text text-3xl font-semibold text-left w-full'>🔮 Mock Drafts</h1>
                 {hasDrafts && (
                     <button
                         type="button"
@@ -57,7 +62,7 @@ const MockDraftsPage = () => {
                     </button>
                 )}
 
-                <div className={`flex flex-col w-full max-w-5xl space-y-6 ${hasDrafts ? 'mt-8 md:mt-12 px-2 md:px-6' : 'px-6 py-4'}`}>
+                <div className={`flex flex-col w-full space-y-6 ${hasDrafts ? 'mt-8 md:mt-12 px-2 md:px-6' : 'px-6 py-4'}`}>
                     {!hasDrafts && (
                         <>
                             <div className="text-center space-y-2 max-w-lg mx-auto">

--- a/src/pages/user/[id]/mock-drafts.tsx
+++ b/src/pages/user/[id]/mock-drafts.tsx
@@ -2,9 +2,11 @@ import AppHeader from "@/components/layout/AppHeader";
 import PageLogo from "@/components/PageLogo";
 import { useGetLocalStorage } from "@/features/local-storage/hooks";
 import { patchLocalStorageData, setLocalStorageData, updateLocalStorageData } from "@/features/local-storage/local-storage";
+import { useSleeperMockDraftsQuery } from "@/features/mock-drafts/hooks/useSleeperMockDraftsQuery";
 
 const MockDraftsPage = () => {
     const { data: mockDrafts, refetch: refetchMockDrafts } = useGetLocalStorage("mockDrafts");
+    const { drafts } = useSleeperMockDraftsQuery(Object.keys(mockDrafts ?? {}));
 
     const addMockDraft = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
@@ -38,9 +40,9 @@ const MockDraftsPage = () => {
                         <button type="submit" className="bg-alt text-primary-text px-4 py-2 rounded-lg">Add Mock Draft</button>
                     </form>
                     <ul>
-                        {Object.entries(mockDrafts ?? {}).map(([draftId, draftUrl]) => {
+                        {drafts?.map((draft) => {
                             return (
-                                <li key={draftId} className="text-primary-text text-sm">{draftUrl}</li>
+                                <li key={draft.draft_id} className="text-primary-text text-sm">{draft.start_time}</li>
                             )
                         })}
                     </ul>

--- a/src/pages/user/[id]/mock-drafts.tsx
+++ b/src/pages/user/[id]/mock-drafts.tsx
@@ -2,11 +2,13 @@ import AppHeader from "@/components/layout/AppHeader";
 import PageLogo from "@/components/PageLogo";
 import { useGetLocalStorage } from "@/features/local-storage/hooks";
 import { patchLocalStorageData, setLocalStorageData, updateLocalStorageData } from "@/features/local-storage/local-storage";
+import { categorizeMockDraftsByDraftType } from "@/features/mock-drafts/extractors";
 import { useSleeperMockDraftsQuery } from "@/features/mock-drafts/hooks/useSleeperMockDraftsQuery";
 
 const MockDraftsPage = () => {
     const { data: mockDrafts, refetch: refetchMockDrafts } = useGetLocalStorage("mockDrafts");
     const { drafts } = useSleeperMockDraftsQuery(Object.keys(mockDrafts ?? {}));
+    const mockDraftsByCategory = categorizeMockDraftsByDraftType(drafts);
 
     const addMockDraft = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
@@ -40,10 +42,14 @@ const MockDraftsPage = () => {
                         <button type="submit" className="bg-alt text-primary-text px-4 py-2 rounded-lg">Add Mock Draft</button>
                     </form>
                     <ul>
-                        {drafts?.map((draft) => {
-                            return (
-                                <li key={draft.draft_id} className="text-primary-text text-sm">{draft.start_time}</li>
-                            )
+                        {Object.entries(mockDraftsByCategory).map(([category, drafts]) => {
+                            const draftsNode = drafts.map(draft => {
+                                return <p key={draft.metadata.draft_id} className="ml-2">{draft.metadata.start_time}</p>
+                            })
+                            return <li className="text-primary-text">
+                                {category}
+                                {draftsNode}
+                            </li>
                         })}
                     </ul>
                 </div>

--- a/src/server/router/sleeper-api.ts
+++ b/src/server/router/sleeper-api.ts
@@ -3,6 +3,7 @@ import { createRouter } from "./context";
 import { getSleeperUserLeagues, getSleeperUserMatchupsData, getSleeperUserRosterIds } from "@/features/leagues/data";
 import { extractSleeperMatchupData } from "@/features/leagues/extractors";
 import { WEEKS } from "@/utils/consts";
+import { getMockDraftsData } from "@/features/mock-drafts/data";
 
 export const sleeperApiRouter = createRouter()
   .query("getLeagueRosterIds", {
@@ -30,5 +31,16 @@ export const sleeperApiRouter = createRouter()
       const leagueIds = Object.keys(leagueRosterIds);
       const leagueMatchupData = await getSleeperUserMatchupsData(leagueIds, week as WEEKS);
       return extractSleeperMatchupData(leagueMatchupData, leagueRosterIds);
+    }
+  })
+  .query("getMockDraftsData", {
+    input: z.object({
+      mockDraftIds: z.array(z.string())
+    }).nullish(),
+    async resolve({input}) {
+      const mockDraftIds = input?.mockDraftIds;
+      if (!mockDraftIds) return [];
+      const mockDraftData = await getMockDraftsData(mockDraftIds);
+      return mockDraftData;
     }
   });

--- a/src/server/router/sleeper-api.ts
+++ b/src/server/router/sleeper-api.ts
@@ -3,7 +3,7 @@ import { createRouter } from "./context";
 import { getSleeperUserLeagues, getSleeperUserMatchupsData, getSleeperUserRosterIds } from "@/features/leagues/data";
 import { extractSleeperMatchupData } from "@/features/leagues/extractors";
 import { WEEKS } from "@/utils/consts";
-import { getMockDraftsData } from "@/features/mock-drafts/data";
+import { getMockDrafts } from "@/features/mock-drafts/data";
 
 export const sleeperApiRouter = createRouter()
   .query("getLeagueRosterIds", {
@@ -39,8 +39,8 @@ export const sleeperApiRouter = createRouter()
     }).nullish(),
     async resolve({input}) {
       const mockDraftIds = input?.mockDraftIds;
-      if (!mockDraftIds) return [];
-      const mockDraftData = await getMockDraftsData(mockDraftIds);
+      if (!mockDraftIds) return {};
+      const mockDraftData = await getMockDrafts(mockDraftIds);
       return mockDraftData;
     }
   });


### PR DESCRIPTION
1. New mock drafts page
2. Add new mock drafts via Sleeper sharable link
3. Fetch each drafts metadata and picks (trpc-backend/useQuery hook/local-storage persistence)
4. Show all mock drafts in a nice grid UI with the ability to filter via draft type and pick order.
5. Wirings (navigation/bi)