### PR TITLE
add close matchups filter

### DIFF
--- a/src/features/leagues/extractors.ts
+++ b/src/features/leagues/extractors.ts
@@ -42,22 +42,36 @@ const extractStartersData = (matchups: Partial<LeagueMatchupWithLeagueId>[]) => 
     return starterData;
 }
 
-export const extractSleeperMatchupData = (leagueMatchupsData: { [leagueId: string]: LeagueMatchup[] }, leagueRosterIds: LeagueRosterIdsMap)
+export const extractSleeperMatchupData = (leagueMatchupsData: { [leagueId: string]: LeagueMatchup[] }, leagueRosterIds: LeagueRosterIdsMap, closeMatchupMargin?: number | null)
     : { userStarters?: Starters; oppStarters?: Starters } => {
     const userMatchups = Object.entries(leagueMatchupsData).map(([leagueId, leagueMatchups]) => {
         const userMatchup = leagueMatchups.find(isUserMatchup(leagueRosterIds[leagueId]));
-        if (!userMatchup) return { leagueId, matchup_id: 'N/A' };
+        if (!userMatchup) return { leagueId, matchup_id: 'N/A', points: 0 };
         return { ...userMatchup, leagueId }
     });
-    const userStarters = extractStartersData(userMatchups);
     const oppMatchups = Object.entries(leagueMatchupsData).map(([leagueId, leagueMatchups], index) => {
         const matchupId = userMatchups[index]?.matchup_id;
         const userRosterId = leagueRosterIds[leagueId];
         const oppMatchup = leagueMatchups.find(isOppMatchup(matchupId, userRosterId));
-        if (!oppMatchup) return { leagueId, matchup_id: 'N/A' };
+        if (!oppMatchup) return { leagueId, matchup_id: 'N/A', points: 0 };
         return { ...oppMatchup, leagueId };
     })
-    const oppStarters = extractStartersData(oppMatchups);
+
+    const userCloseMarginMatchups = userMatchups.filter(userMatchup => {
+        if (!closeMatchupMargin) return true;
+        const userMatchupPoints = userMatchup.points;
+        const oppMatchupPoints = oppMatchups.find(oppMatchup => oppMatchup.leagueId === userMatchup.leagueId)?.points;
+        if (!oppMatchupPoints) return false;
+        const leadMargin = 1 + closeMatchupMargin/100;
+        const trailingMargin = 1 - closeMatchupMargin/100;
+        const userWithinMaxLead = (userMatchupPoints/oppMatchupPoints) <= leadMargin;
+        const userWithinMinTrail = (userMatchupPoints/oppMatchupPoints) >= trailingMargin;
+        return userWithinMaxLead && userWithinMinTrail;
+    })
+
+    const oppCloseMarginMatchups = oppMatchups.filter(oppMatchup => userCloseMarginMatchups.find(userMatchup => userMatchup.leagueId === oppMatchup.leagueId))
+    const userStarters = extractStartersData(userCloseMarginMatchups);
+    const oppStarters = extractStartersData(oppCloseMarginMatchups);
 
     // assign conflicts
     if (userStarters) {

--- a/src/features/leagues/leagues.types.ts
+++ b/src/features/leagues/leagues.types.ts
@@ -9,6 +9,7 @@ export type LeagueMatchup = {
     roster_id: number;
     starters: string[];
     starters_points: number[];
+    points: number;
 };
 
 export type StarterInfo = {

--- a/src/features/local-storage/local-storage.ts
+++ b/src/features/local-storage/local-storage.ts
@@ -14,6 +14,8 @@ type CacheUserSettings = {
     leagueIgnoresMap: LeagueIgnoresMap;
     shouldShowMissingStarters: boolean;
     shouldShowAverageScore: boolean;
+    shouldShowCloseMatchupMargin: boolean;
+    closeMatchupMargin: number | null;
 }
 
 type CacheUserLeaguesInfo = {

--- a/src/features/settings/bi.ts
+++ b/src/features/settings/bi.ts
@@ -7,6 +7,8 @@ type LogSettingsSubmittedProps = {
   leagueIgnoresMap: LeagueIgnoresMap;
   shouldShowMissingStarters: boolean;
   shouldShowAverageScore: boolean;
+  shouldShowCloseMatchupMargin: boolean;
+  closeMatchupMargin: number | null;
 }
 export const logSettingsSubmitted = (settingsProps: LogSettingsSubmittedProps) => gtag.submitEvent({
   category: 'settings',
@@ -15,7 +17,9 @@ export const logSettingsSubmitted = (settingsProps: LogSettingsSubmittedProps) =
   ignored_leagues: Object.values(settingsProps.leagueIgnoresMap).filter(check => !check).length,
   weighted_leagues: Object.values(settingsProps.leagueWeightsMap).filter(weight => weight > 0).length,
   show_missing_starters: settingsProps.shouldShowMissingStarters,
-  show_average_scores: settingsProps.shouldShowAverageScore
+  show_average_scores: settingsProps.shouldShowAverageScore,
+  show_close_matchup_margin: settingsProps.shouldShowCloseMatchupMargin,
+  close_matchup_margin: settingsProps.closeMatchupMargin,
 })
 
 export const logSettingsSkipped = () => gtag.submitEvent({

--- a/src/features/settings/useSettings.ts
+++ b/src/features/settings/useSettings.ts
@@ -9,6 +9,8 @@ export const useSettings = (leagues: SleeperLeagueData[]) => {
     const { data: cachedSettings, cacheStatus: cachedSettingsStatus } = useGetLocalStorage('settings');
     const [leagueWeightsMap, setLeagueWeightsMap] = useState<LeagueWeightsMap>(cachedSettingsStatus === CacheStatus.HIT ? cachedSettings!.leagueWeightsMap : {});
     const [leagueIgnoresMap, setLeagueIgnoresMap] = useState<LeagueIgnoresMap>(cachedSettingsStatus === CacheStatus.HIT ? cachedSettings!.leagueIgnoresMap : {});
+    const [shouldShowCloseMatchupMargin, setShouldShowCloseMatchupMargin] = useState<boolean>(cachedSettingsStatus === CacheStatus.HIT ? cachedSettings!.shouldShowCloseMatchupMargin : false);
+    const [closeMatchupMargin, setCloseMatchupMargin] = useState<number | null>(cachedSettingsStatus === CacheStatus.HIT ? cachedSettings!.closeMatchupMargin : null);
     const [shouldShowMissingStarters, setShouldShowMissingStarters] = useState<boolean>(cachedSettingsStatus === CacheStatus.HIT ? cachedSettings!.shouldShowMissingStarters : true);
     const [shouldShowAverageScore, setShouldShowAverageScore] = useState<boolean>(cachedSettingsStatus === CacheStatus.HIT ? cachedSettings!.shouldShowAverageScore : true);
     useEffect(() => {
@@ -17,6 +19,8 @@ export const useSettings = (leagues: SleeperLeagueData[]) => {
             setLeagueIgnoresMap(cachedSettings.leagueIgnoresMap);
             setShouldShowMissingStarters(cachedSettings.shouldShowMissingStarters);
             setShouldShowAverageScore(cachedSettings.shouldShowAverageScore);
+            setShouldShowCloseMatchupMargin(cachedSettings.shouldShowCloseMatchupMargin ?? false);
+            setCloseMatchupMargin(cachedSettings.closeMatchupMargin ?? null)
         }
     }, [cachedSettingsStatus]);
 
@@ -43,14 +47,27 @@ export const useSettings = (leagues: SleeperLeagueData[]) => {
         setShouldShowAverageScore(shouldShow);
     }
 
+    const onChangeShowCloseMatchupMargin = (shouldShow: boolean) => {
+        setShouldShowCloseMatchupMargin(shouldShow);
+    }
+
+    const onChangeCloseMatchupMargin = (margin: number) => {
+        if (Number.isNaN(margin)) return;
+        setCloseMatchupMargin(margin);
+    }
+
     return {
         leagueIgnoresMap,
         leagueWeightsMap,
         shouldShowMissingStarters,
         shouldShowAverageScore,
+        closeMatchupMargin,
+        shouldShowCloseMatchupMargin,
         onChangeLeagueIgnore,
         onChangeLeagueWeight,
         onChangeShowMissingStarters,
-        onChangeShowAverageScore
+        onChangeShowAverageScore,
+        onChangeShowCloseMatchupMargin,
+        onChangeCloseMatchupMargin
     };
 };

--- a/src/features/user/hooks/useSleeperUserMatchupsData.ts
+++ b/src/features/user/hooks/useSleeperUserMatchupsData.ts
@@ -1,12 +1,17 @@
-import { LeagueRosterIdsMap, LeagueIgnoresMap } from "@/features/local-storage/local-storage";
+import { LeagueRosterIdsMap, Cache } from "@/features/local-storage/local-storage";
 import { WEEKS } from "@/utils/consts";
 import { trpc } from "@/utils/trpc";
 import { useState, useEffect } from "react";
 
 // @TODO: error handling
-export const useSleeperUserMatchupsData = (week: WEEKS, leagueRosterIds?: LeagueRosterIdsMap, leagueIgnores?: LeagueIgnoresMap) => {
+export const useSleeperUserMatchupsData = (week: WEEKS, leagueRosterIds?: LeagueRosterIdsMap, settings?: Cache['settings']) => {
     const [filteredLeagueRosterIds, setFilteredRosterIds] = useState<LeagueRosterIdsMap>();
-    const {data: matchups, isLoading: isMatchupsLoading} = trpc.useQuery(['sleeper-api.getMatchupsData', {week, leagueRosterIds: filteredLeagueRosterIds!}]);
+    const {data: matchups, isLoading: isMatchupsLoading} = trpc.useQuery(['sleeper-api.getMatchupsData', {
+        week,
+        leagueRosterIds: filteredLeagueRosterIds!,
+        closeMatchupMargin: settings?.shouldShowCloseMatchupMargin ? settings?.closeMatchupMargin : undefined
+    }]);
+    const leagueIgnores = settings?.leagueIgnoresMap;
 
     useEffect(() => {
         if (leagueRosterIds && leagueIgnores) {
@@ -18,7 +23,7 @@ export const useSleeperUserMatchupsData = (week: WEEKS, leagueRosterIds?: League
             });
             setFilteredRosterIds(newLeagueRosterIds);
         }
-    }, [leagueRosterIds]);
+    }, [leagueRosterIds, leagueIgnores]);
 
     return {matchups, isMatchupsLoading};
 }

--- a/src/pages/user/[id]/index.tsx
+++ b/src/pages/user/[id]/index.tsx
@@ -24,9 +24,8 @@ const UserDashboardPage = (props: { nflWeek: WEEKS }) => {
     const { data: cachedSettings } = useGetLocalStorage('settings');
     const { data: cachedUserInfo } = useGetLocalStorage('user');
     const { leagueRosterIds, isLeagueRosterIdsLoading } = useSleeperUserRosterIds(id as string);
-    const { matchups, isMatchupsLoading } = useSleeperUserMatchupsData(selectedWeek, leagueRosterIds, cachedSettings?.leagueIgnoresMap);
+    const { matchups, isMatchupsLoading } = useSleeperUserMatchupsData(selectedWeek, leagueRosterIds, cachedSettings);
     const { userStarters, oppStarters } = matchups ?? {};
-    console.log('@selectedWeek', selectedWeek)
     const { data: scheduleData, isLoading: isScheduleLoading } = useQuery({
         queryKey: ['nfl-schedule', selectedWeek],
         queryFn: () => getScheduleData(selectedWeek)

--- a/src/pages/user/[id]/settings.tsx
+++ b/src/pages/user/[id]/settings.tsx
@@ -18,8 +18,8 @@ type UserDashboardPageProps = InferGetServerSidePropsType<typeof getServerSidePr
 const UserDashboardPage = ({ leagues }: UserDashboardPageProps) => {
     const router = useRouter();
     const { id, fromLogin } = router.query;
-    const { leagueIgnoresMap, leagueWeightsMap, shouldShowMissingStarters, shouldShowAverageScore,
-        onChangeLeagueIgnore, onChangeLeagueWeight, onChangeShowMissingStarters, onChangeShowAverageScore } = useSettings(leagues);
+    const { leagueIgnoresMap, leagueWeightsMap, shouldShowMissingStarters, shouldShowAverageScore, shouldShowCloseMatchupMargin, closeMatchupMargin,
+        onChangeLeagueIgnore, onChangeLeagueWeight, onChangeShowMissingStarters, onChangeShowAverageScore, onChangeShowCloseMatchupMargin, onChangeCloseMatchupMargin } = useSettings(leagues);
 
     // move outside of component
     const submitWeightsHandler = (isSkipped = false) => {
@@ -32,7 +32,9 @@ const UserDashboardPage = ({ leagues }: UserDashboardPageProps) => {
             shouldShowMissingStarters,
             shouldShowAverageScore,
             leagueIgnoresMap,
-            leagueWeightsMap
+            leagueWeightsMap,
+            shouldShowCloseMatchupMargin,
+            closeMatchupMargin,
         });
         safeUpdateLocalStorageData('leaguesInfo', {
             leagueNames,
@@ -41,7 +43,7 @@ const UserDashboardPage = ({ leagues }: UserDashboardPageProps) => {
         if (isSkipped) {
             bi.logSettingsSkipped();
         } else {
-            bi.logSettingsSubmitted({ leagueNames, leagueWeightsMap, leagueIgnoresMap, shouldShowMissingStarters, shouldShowAverageScore })
+            bi.logSettingsSubmitted({ leagueNames, leagueWeightsMap, leagueIgnoresMap, shouldShowMissingStarters, shouldShowAverageScore, shouldShowCloseMatchupMargin, closeMatchupMargin })
         }
         router.replace(`/user/${id}`);
     };
@@ -96,6 +98,33 @@ const UserDashboardPage = ({ leagues }: UserDashboardPageProps) => {
                                     <label htmlFor='average_score_checkbox'
                                         className="text-primary-text text-sm pl-5 md:text-base">Show average scores</label>
                                 </div>
+                                <div className="flex justify-between mb-6 sm:space-x-5 lg:space-x-8">
+                                    <div className='flex'>
+                                        <input type='checkbox'
+                                            id='close_matchup_margin_checkbox'
+                                            className='w-4 checked:accent-alt rounded-lg md:w-5'
+                                            checked={shouldShowCloseMatchupMargin} onChange={event => onChangeShowCloseMatchupMargin(event.target.checked)} />
+                                        <div>
+                                            <label htmlFor={'close_matchup_margin_checkbox'}
+                                                className="text-primary-text text-sm pl-5 md:text-base">Close matchup margin</label>
+                                            <p className="text-alt text-xs pl-5 md:text-sm">{'Filter to matchups within a % difference'}</p>
+                                        </div>
+                                    </div>
+                                    <div className="relative inline-flex items-center">
+                                        <input type="number" onChange={event => onChangeCloseMatchupMargin(parseInt(event.target.value))}
+                                            step={1} min={1} max={99} value={closeMatchupMargin ?? 0}
+                                            disabled={!shouldShowCloseMatchupMargin}
+                                            id={'close_matchup_margin_input'}
+                                            className="peer max-w-[60px] md:max-w-[72px] max-h-[40px] pl-2 pr-6 text-center text-grey-700
+                                            border-[3px] border-solid border-grey-300
+                                            transition ease-in-out
+                                            focus:text-primary focus:border-alt focus:border-[2px] focus:outline-none
+                                            md:text-md"
+                                        />
+                                        <span className="pointer-events-none absolute right-2 text-sm text-grey-700
+                                            transition ease-in-out peer-focus:text-primary md:text-md">%</span>
+                                    </div>
+                                </div>
                                 <button className="text-primary-text rounded-lg bg-alt w-full py-3"
                                     onClick={() => submitWeightsHandler(false)}>
                                     Submit
@@ -109,11 +138,11 @@ const UserDashboardPage = ({ leagues }: UserDashboardPageProps) => {
                     </section>
                 </FlexibleContainer>
 
-            <PageFooter>
-                <Link href="/">
-                    <button className="text-primary-text tracking-wide bg-accent px-2 py-1 rounded">Change user</button>
-                </Link>
-            </PageFooter>
+                <PageFooter>
+                    <Link href="/">
+                        <button className="text-primary-text tracking-wide bg-accent px-2 py-1 rounded">Change user</button>
+                    </Link>
+                </PageFooter>
             </main>
         </>
     )

--- a/src/server/router/sleeper-api.ts
+++ b/src/server/router/sleeper-api.ts
@@ -22,15 +22,17 @@ export const sleeperApiRouter = createRouter()
   .query("getMatchupsData", {
     input: z.object({
       leagueRosterIds: z.record(z.number()),
-      week: z.string()
+      week: z.string(),
+      closeMatchupMargin: z.number().nullish()
     }).nullish(),
     async resolve({input}) {
       const leagueRosterIds = input?.leagueRosterIds;
       const week = input?.week;
       if (!leagueRosterIds || !week) return {};
       const leagueIds = Object.keys(leagueRosterIds);
+      const closeMatchupMargin = input?.closeMatchupMargin;
       const leagueMatchupData = await getSleeperUserMatchupsData(leagueIds, week as WEEKS);
-      return extractSleeperMatchupData(leagueMatchupData, leagueRosterIds);
+      return extractSleeperMatchupData(leagueMatchupData, leagueRosterIds, closeMatchupMargin);
     }
   })
   .query("getMockDraftsData", {


### PR DESCRIPTION
Add a settings filter to allow users to see only matchups that are within some % of margin.
This allows users with a lot of leagues to filter out only winnable matchups in a late-week scenario.

1. Add settings page UI + local-storage wire-up
2. Add server-side filtering as part of the "getMatchups" flow.